### PR TITLE
Add transient game generator endpoint for oodlu

### DIFF
--- a/src/main/java/uk/ac/ucl/rits/popchat/SongEndpoints.java
+++ b/src/main/java/uk/ac/ucl/rits/popchat/SongEndpoints.java
@@ -82,7 +82,7 @@ public class SongEndpoints {
     public Game playGame(@PathVariable("songId") long songId, Principal principal) {
         Optional<Song> songSearch = songRepo.findById(songId);
         if (songSearch.isEmpty()) {
-            throw new IllegalArgumentException("So such song " + songId);
+            throw new IllegalArgumentException("No such song " + songId);
         }
         Song song = songSearch.get();
         Lyrics lyrics = new Lyrics(song);
@@ -94,6 +94,26 @@ public class SongEndpoints {
         }
         game.setUser(user);
         game = this.gameRepo.save(game);
+
+        return new Game(game);
+    }
+
+    /**
+     * Generate transient game for a given song with a specific number of question.
+     *
+     * @param songId    Song to generate the game for
+     * @param number    Number of questions to generate
+     * @return Game to generate
+     */
+    @GetMapping("/generate/{songId}")
+    public Game playGame(@PathVariable("songId") long songId, @RequestParam("num") int number) {
+        Optional<Song> songSearch = songRepo.findById(songId);
+        if (songSearch.isEmpty()) {
+            throw new IllegalArgumentException("No such song " + songId);
+        }
+        Song song = songSearch.get();
+        Lyrics lyrics = new Lyrics(song);
+        SongGame game = new SongGame(song, lyrics, number);
 
         return new Game(game);
     }
@@ -124,8 +144,8 @@ public class SongEndpoints {
     }
 
     /**
-     * Set the details for a song. Editing them if necessary.
-     * A song is being edited only if it has an ID.
+     * Set the details for a song. Editing them if necessary. A song is being edited
+     * only if it has an ID.
      *
      * @param song Song details to update
      * @return Outcomes of attempting to insert the song

--- a/src/main/java/uk/ac/ucl/rits/popchat/game/SongGame.java
+++ b/src/main/java/uk/ac/ucl/rits/popchat/game/SongGame.java
@@ -97,6 +97,45 @@ public class SongGame {
 
     }
 
+
+    /**
+     * Create a new game from a song with its words.
+     * This will cover the full song with a specified number of questions.
+     *
+     * @param song   The song
+     * @param lyrics The songs lyrics
+     * @param number Number of questions
+     */
+    public SongGame(Song song, Lyrics lyrics, int number) {
+        this.song = song;
+
+        this.songStartSeconds = lyrics.getStartTime().toSecondOfDay();
+        this.songEndSeconds = lyrics.getEndTime().toSecondOfDay();
+
+        Rhymes rhymes = Rhymes.getRhymes();
+        List<Lyrics> questionSequence = lyrics.split(number);
+
+        this.questions = new ArrayList<>();
+        for (Lyrics subFragment : questionSequence) {
+            Set<Set<String>> multiWords = rhymes.createRhymesWithGame(subFragment);
+            Pair<String, String> question = this.pickRandomPair(multiWords);
+            if (question == null) {
+                question = this.pickRandomQuestion(subFragment, rhymes, 10);
+                if (question == null) {
+                    continue;
+                }
+            }
+            Set<String> uniqueLyrics = new HashSet<>(subFragment.getWords());
+            uniqueLyrics.remove(question.getFirst());
+            uniqueLyrics.remove(question.getSecond());
+
+            this.questions.add(generateQuestion(question.getFirst(), question.getSecond(), subFragment.getStartTime(),
+                    subFragment.getEndTime(), new ArrayList<>(uniqueLyrics), rhymes));
+
+        }
+
+    }
+
     /**
      * Try generate a random question based on any given word.
      *

--- a/src/main/java/uk/ac/ucl/rits/popchat/songs/Lyrics.java
+++ b/src/main/java/uk/ac/ucl/rits/popchat/songs/Lyrics.java
@@ -327,4 +327,46 @@ public class Lyrics {
         }
         return fragments;
     }
+
+
+    /**
+     * Fragment a set of Lyrics into a sequence set of size count.
+     *
+     * @param count Number of chunks to break the lyrics into (must be >=1)
+     * @return list of sequential lyrics
+     */
+    public List<Lyrics> split(int count) {
+        if (count < 1) {
+            throw new IllegalArgumentException("Count must be >= 1 but is " + count);
+        }
+        long songLines = this.lyrics.values().stream().filter(line -> !line.isEmpty()).count();
+
+        long base  = songLines / count;
+        long overflow = songLines % count;
+
+        List<Lyrics> fragments = new ArrayList<>();
+        Lyrics current = new Lyrics();
+        int lyricsInCurrent = 0;
+        for (Map.Entry<LocalTime, String> line : this.lyrics.entrySet()) {
+            final String lyric = line.getValue();
+            if (!lyric.isEmpty() && lyricsInCurrent > 0 && lyricsInCurrent % (overflow > 0 ? base + 1 : base) == 0) {
+                // The bland end line serves to tell us properly how long this section is.
+                current.addLine(line.getKey(), "");
+                fragments.add(current);
+                current = new Lyrics();
+                overflow--;
+                lyricsInCurrent = 0;
+            }
+            current.addLine(line.getKey(), lyric);
+            if (!lyric.isEmpty()) {
+                // Only interesting lines count
+                lyricsInCurrent++;
+            }
+        }
+        if (!current.isEmpty()) {
+            // the last current might not have been added. It also might be empty
+            fragments.add(current);
+        }
+        return fragments;
+    }
 }

--- a/src/test/java/uk/ac/ucl/rits/popchat/rhyming/SongsTest.java
+++ b/src/test/java/uk/ac/ucl/rits/popchat/rhyming/SongsTest.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import uk.ac.ucl.rits.popchat.game.SongGame;
 import uk.ac.ucl.rits.popchat.songs.Lyrics;
 import uk.ac.ucl.rits.popchat.songs.Song;
 import uk.ac.ucl.rits.popchat.songs.SongRepository;
@@ -133,5 +134,26 @@ public class SongsTest {
 
             }
         }
+    }
+
+    /**
+     * Test to make sure that create game of fixed size returns the right number of
+     * questions.
+     */
+    @Test
+    public void testCreateFixedSizeTransientGame() {
+        List<Song> songs = songRepo.findByTitleIgnoreCase("Alexander Hamilton");
+
+        // There should only be one song called Hamilton
+        assert songs.size() == 1;
+        Song song = songs.get(0);
+
+        Lyrics lyrics = new Lyrics(song);
+
+        for (int i = 2; i < 15; i++) {
+            SongGame game = new SongGame(song, lyrics, i);
+            assertTrue(String.format("Failed for size %d", i), game.getQuestions().size() == i);
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #32 

Created an endpoint that creates games with a fixed number of questions. These are not saved to the database as they are for external consumption.
The endpoint is: `GET /generate/{songid}?num={questions}`